### PR TITLE
chore(prettier): add more verbose options to prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,12 @@
 {
   "trailingComma": "all",
   "semi": true,
+  "tabWidth": 2,
+  "printWidth": 120,
   "singleQuote": true,
-  "htmlWhitespaceSensitivity": "ignore"
+  "singleAttributePerLine": true,
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "always",
+  "vueIndentScriptAndStyle": false
 }


### PR DESCRIPTION
* Added some opinionated options to the file (even if with the default values; adds visibility to them)
* Added `singleAttributePerLine` which was conflicting with Vue's recommended rules
* Removed `"htmlWhitespaceSensitivity": "ignore"`